### PR TITLE
Zlw decoupling viewholder

### DIFF
--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/AnimationAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/AnimationAdapter.java
@@ -23,7 +23,7 @@ import com.chad.library.adapter.base.BaseViewHolder;
  * 修改时间：
  * 修改备注：
  */
-public class AnimationAdapter extends BaseQuickAdapter<Status, BaseViewHolder> {
+public class AnimationAdapter extends BaseQuickAdapter<Status, BaseViewHolder<Status>> {
     public AnimationAdapter() {
         super(R.layout.layout_animation, DataServer.getSampleData(100));
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/DataBindingUseAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/DataBindingUseAdapter.java
@@ -62,7 +62,7 @@ public class DataBindingUseAdapter extends BaseQuickAdapter<Movie, DataBindingUs
         return view;
     }
 
-    public static class MovieViewHolder extends BaseViewHolder {
+    public static class MovieViewHolder extends BaseViewHolder<Movie> {
 
         public MovieViewHolder(View view) {
             super(view);

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/ExpandableItemAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/ExpandableItemAdapter.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Created by luoxw on 2016/8/9.
  */
-public class ExpandableItemAdapter extends BaseMultiItemQuickAdapter<MultiItemEntity, BaseViewHolder> {
+public class ExpandableItemAdapter extends BaseMultiItemQuickAdapter<MultiItemEntity, BaseViewHolder<MultiItemEntity>> {
     private static final String TAG = ExpandableItemAdapter.class.getSimpleName();
 
     public static final int TYPE_LEVEL_0 = 0;

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/HeaderAndFooterAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/HeaderAndFooterAdapter.java
@@ -9,7 +9,7 @@ import com.chad.library.adapter.base.BaseViewHolder;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public class HeaderAndFooterAdapter extends BaseQuickAdapter<Status, BaseViewHolder> {
+public class HeaderAndFooterAdapter extends BaseQuickAdapter<Status, BaseViewHolder<Status>> {
 
     public HeaderAndFooterAdapter(int dataSize) {
         super(R.layout.item_header_and_footer, DataServer.getSampleData(dataSize));

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/HomeAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/HomeAdapter.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public class HomeAdapter extends BaseQuickAdapter<HomeItem, BaseViewHolder> {
+public class HomeAdapter extends BaseQuickAdapter<HomeItem, BaseViewHolder<HomeItem>> {
     public HomeAdapter(int layoutResId, List data) {
         super(layoutResId, data);
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/ItemClickAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/ItemClickAdapter.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  *
  */
-public class ItemClickAdapter extends BaseMultiItemQuickAdapter<ClickEntity, BaseViewHolder> implements BaseQuickAdapter.OnItemClickListener, BaseQuickAdapter.OnItemChildClickListener {
+public class ItemClickAdapter extends BaseMultiItemQuickAdapter<ClickEntity, BaseViewHolder<ClickEntity>> implements BaseQuickAdapter.OnItemClickListener, BaseQuickAdapter.OnItemChildClickListener {
     NestAdapter nestAdapter;
 
     public ItemClickAdapter(List<ClickEntity> data) {
@@ -52,7 +52,7 @@ public class ItemClickAdapter extends BaseMultiItemQuickAdapter<ClickEntity, Bas
                 break;
             case ClickEntity.NEST_CLICK_ITEM_CHILD_VIEW:
                 helper.setNestView(R.id.item_click); // u can set nestview id
-                final RecyclerView recyclerView = helper.getView(R.id.nest_list);
+                final RecyclerView recyclerView = (RecyclerView) helper.getView(R.id.nest_list);
                 recyclerView.setLayoutManager(new LinearLayoutManager(helper.itemView.getContext(), LinearLayoutManager.VERTICAL, false));
                 recyclerView.setHasFixedSize(true);
 

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/ItemDragAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/ItemDragAdapter.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Created by luoxw on 2016/6/20.
  */
-public class ItemDragAdapter extends BaseItemDraggableAdapter<String, BaseViewHolder> {
+public class ItemDragAdapter extends BaseItemDraggableAdapter<String, BaseViewHolder<String>> {
     public ItemDragAdapter(List data) {
         super(R.layout.item_draggable_view, data);
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemQuickAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemQuickAdapter.java
@@ -1,8 +1,13 @@
 package com.chad.baserecyclerviewadapterhelper.adapter;
 
 import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
 
 import com.chad.baserecyclerviewadapterhelper.R;
+import com.chad.baserecyclerviewadapterhelper.adapter.viewholder.ImageTextHolder;
+import com.chad.baserecyclerviewadapterhelper.adapter.viewholder.TextHolder;
 import com.chad.baserecyclerviewadapterhelper.entity.MultipleItem;
 import com.chad.library.adapter.base.BaseMultiItemQuickAdapter;
 import com.chad.library.adapter.base.BaseViewHolder;
@@ -13,7 +18,7 @@ import java.util.List;
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  * modify by AllenCoder
  */
-public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<MultipleItem, BaseViewHolder> {
+public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<MultipleItem, BaseViewHolder<MultipleItem>> {
 
     public MultipleItemQuickAdapter(Context context, List data) {
         super(data);
@@ -23,24 +28,19 @@ public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<Multiple
     }
 
     @Override
-    protected void convert(BaseViewHolder helper, MultipleItem item) {
-        switch (helper.getItemViewType()) {
+    protected BaseViewHolder<MultipleItem> onCreateDefViewHolder(ViewGroup parent, int viewType) {
+        switch (viewType) {
             case MultipleItem.TEXT:
-                helper.setText(R.id.tv, item.getContent());
-                break;
+                return new TextHolder(getItemView(R.layout.item_text_view, parent));
             case MultipleItem.IMG_TEXT:
-                switch (helper.getLayoutPosition() %
-                        2) {
-                    case 0:
-                        helper.setImageResource(R.id.iv, R.mipmap.animation_img1);
-                        break;
-                    case 1:
-                        helper.setImageResource(R.id.iv, R.mipmap.animation_img2);
-                        break;
-
-                }
-                break;
+                return new ImageTextHolder(getItemView(R.layout.item_img_text_view, parent));
+            default:
+                return super.onCreateDefViewHolder(parent, viewType);
         }
     }
 
+    @Override
+    protected void convert(BaseViewHolder<MultipleItem> helper, MultipleItem item) {
+        super.convert(helper, item);
+    }
 }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemQuickAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemQuickAdapter.java
@@ -38,9 +38,4 @@ public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<Multiple
                 return super.onCreateDefViewHolder(parent, viewType);
         }
     }
-
-    @Override
-    protected void convert(BaseViewHolder<MultipleItem> helper, MultipleItem item) {
-        super.convert(helper, item);
-    }
 }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/NestAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/NestAdapter.java
@@ -8,7 +8,6 @@ import android.widget.TextView;
 
 import com.chad.baserecyclerviewadapterhelper.R;
 import com.chad.baserecyclerviewadapterhelper.data.DataServer;
-import com.chad.baserecyclerviewadapterhelper.entity.ClickEntity;
 import com.chad.baserecyclerviewadapterhelper.entity.Status;
 import com.chad.baserecyclerviewadapterhelper.util.SpannableStringUtils;
 import com.chad.baserecyclerviewadapterhelper.util.ToastUtils;

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/NestAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/NestAdapter.java
@@ -8,6 +8,7 @@ import android.widget.TextView;
 
 import com.chad.baserecyclerviewadapterhelper.R;
 import com.chad.baserecyclerviewadapterhelper.data.DataServer;
+import com.chad.baserecyclerviewadapterhelper.entity.ClickEntity;
 import com.chad.baserecyclerviewadapterhelper.entity.Status;
 import com.chad.baserecyclerviewadapterhelper.util.SpannableStringUtils;
 import com.chad.baserecyclerviewadapterhelper.util.ToastUtils;
@@ -23,7 +24,7 @@ import com.chad.library.adapter.base.BaseViewHolder;
  * 修改时间：
  * 修改备注：
  */
-public class NestAdapter extends BaseQuickAdapter<Status, BaseViewHolder> {
+public class NestAdapter extends BaseQuickAdapter<Status, BaseViewHolder<Status>> {
     public NestAdapter() {
         super( R.layout.layout_nest_item, DataServer.getSampleData(20));
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/PullToRefreshAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/PullToRefreshAdapter.java
@@ -22,7 +22,7 @@ import com.chad.library.adapter.base.BaseViewHolder;
  * 修改时间：
  * 修改备注：
  */
-public class PullToRefreshAdapter extends BaseQuickAdapter<Status, BaseViewHolder> {
+public class PullToRefreshAdapter extends BaseQuickAdapter<Status, BaseViewHolder<Status>> {
     public PullToRefreshAdapter() {
         super( R.layout.layout_animation, null);
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/QuickAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/QuickAdapter.java
@@ -16,7 +16,7 @@ import com.chad.library.adapter.base.BaseViewHolder;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public class QuickAdapter extends BaseQuickAdapter<Status, BaseViewHolder> {
+public class QuickAdapter extends BaseQuickAdapter<Status, BaseViewHolder<Status>> {
 
     public QuickAdapter(int dataSize) {
         super(R.layout.layout_animation, DataServer.getSampleData(dataSize));

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/SectionAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/SectionAdapter.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public class SectionAdapter extends BaseSectionQuickAdapter<MySection, BaseViewHolder> {
+public class SectionAdapter extends BaseSectionQuickAdapter<MySection, BaseViewHolder<MySection>> {
     /**
      * Same as QuickAdapter#QuickAdapter(Context,int) but with
      * some initialization data.

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/viewholder/ImageTextHolder.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/viewholder/ImageTextHolder.java
@@ -1,0 +1,33 @@
+package com.chad.baserecyclerviewadapterhelper.adapter.viewholder;
+
+import android.view.View;
+
+import com.chad.baserecyclerviewadapterhelper.R;
+import com.chad.baserecyclerviewadapterhelper.entity.MultipleItem;
+import com.chad.library.adapter.base.BaseViewHolder;
+
+/**
+ * Created by Wells on 2017/12/13.
+ */
+
+public class ImageTextHolder extends BaseViewHolder<MultipleItem> {
+
+    public ImageTextHolder(View view) {
+        super(view);
+    }
+
+    @Override
+    public void onBind(MultipleItem data) {
+        super.onBind(data);
+        switch (getLayoutPosition() %
+                2) {
+            case 0:
+                setImageResource(R.id.iv, R.mipmap.animation_img1);
+                break;
+            case 1:
+                setImageResource(R.id.iv, R.mipmap.animation_img2);
+                break;
+
+        }
+    }
+}

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/viewholder/TextHolder.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/viewholder/TextHolder.java
@@ -1,0 +1,24 @@
+package com.chad.baserecyclerviewadapterhelper.adapter.viewholder;
+
+import android.view.View;
+
+import com.chad.baserecyclerviewadapterhelper.R;
+import com.chad.baserecyclerviewadapterhelper.entity.MultipleItem;
+import com.chad.library.adapter.base.BaseViewHolder;
+
+/**
+ * Created by Wells on 2017/12/13.
+ */
+
+public class TextHolder extends BaseViewHolder<MultipleItem> {
+
+    public TextHolder(View view) {
+        super(view);
+    }
+
+    @Override
+    public void onBind(MultipleItem data) {
+        super.onBind(data);
+        setText(R.id.tv, data.getContent());
+    }
+}

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/base/BaseBindingViewHolder.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/base/BaseBindingViewHolder.java
@@ -11,7 +11,7 @@ import com.chad.library.adapter.base.BaseViewHolder;
  * Email: tyshengsx@gmail.com
  */
 
-public class BaseBindingViewHolder<Binding extends ViewDataBinding> extends BaseViewHolder {
+public class BaseBindingViewHolder<Binding extends ViewDataBinding,T> extends BaseViewHolder<T> {
     private Binding mBinding;
 
     public BaseBindingViewHolder(View view) {

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/base/BaseDataBindingAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/base/BaseDataBindingAdapter.java
@@ -18,7 +18,7 @@ import java.util.List;
  * Email: tyshengsx@gmail.com
  */
 
-public abstract class BaseDataBindingAdapter<T, Binding extends ViewDataBinding> extends BaseQuickAdapter<T, BaseBindingViewHolder<Binding>> {
+public abstract class BaseDataBindingAdapter<T, Binding extends ViewDataBinding> extends BaseQuickAdapter<T,BaseBindingViewHolder<Binding,T>> {
 
 
     public BaseDataBindingAdapter(@LayoutRes int layoutResId, @Nullable List<T> data) {
@@ -34,12 +34,12 @@ public abstract class BaseDataBindingAdapter<T, Binding extends ViewDataBinding>
     }
 
     @Override
-    protected BaseBindingViewHolder<Binding> createBaseViewHolder(View view) {
+    protected BaseBindingViewHolder<Binding,T> createBaseViewHolder(View view) {
         return new BaseBindingViewHolder<>(view);
     }
 
     @Override
-    protected BaseBindingViewHolder<Binding> createBaseViewHolder(ViewGroup parent, int layoutResId) {
+    protected BaseBindingViewHolder<Binding,T> createBaseViewHolder(ViewGroup parent, int layoutResId) {
         Binding binding = DataBindingUtil.inflate(mLayoutInflater, layoutResId, parent, false);
         View view;
         if (binding == null) {
@@ -47,13 +47,13 @@ public abstract class BaseDataBindingAdapter<T, Binding extends ViewDataBinding>
         } else {
             view = binding.getRoot();
         }
-        BaseBindingViewHolder<Binding> holder = new BaseBindingViewHolder<>(view);
+        BaseBindingViewHolder<Binding,T> holder = new BaseBindingViewHolder<>(view);
         holder.setBinding(binding);
         return holder;
     }
 
     @Override
-    protected void convert(BaseBindingViewHolder<Binding> helper, T item) {
+    protected void convert(BaseBindingViewHolder<Binding,T> helper, T item) {
         convert(helper.getBinding(), item);
         helper.getBinding().executePendingBindings();
     }

--- a/library/src/main/java/com/chad/library/adapter/base/BaseItemDraggableAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseItemDraggableAdapter.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * Created by luoxw on 2016/7/13.
  */
-public abstract class BaseItemDraggableAdapter<T, K extends BaseViewHolder> extends BaseQuickAdapter<T, K> {
+public abstract class BaseItemDraggableAdapter<T, K extends BaseViewHolder<T>> extends BaseQuickAdapter<T, K> {
 
     private static final int NO_TOGGLE_VIEW = 0;
     protected int mToggleViewId = NO_TOGGLE_VIEW;

--- a/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemQuickAdapter.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public abstract class BaseMultiItemQuickAdapter<T extends MultiItemEntity, K extends BaseViewHolder> extends BaseQuickAdapter<T, K> {
+public abstract class BaseMultiItemQuickAdapter<T extends MultiItemEntity, K extends BaseViewHolder<T>> extends BaseQuickAdapter<T, K> {
 
     /**
      * layouts indexed with their types
@@ -36,8 +36,8 @@ public abstract class BaseMultiItemQuickAdapter<T extends MultiItemEntity, K ext
 
     @Override
     protected int getDefItemViewType(int position) {
-        Object item = mData.get(position);
-        if (item instanceof MultiItemEntity) {
+        T item = mData.get(position);
+        if (item != null) {
             return ((MultiItemEntity) item).getItemType();
         }
         return DEFAULT_VIEW_TYPE;

--- a/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemQuickAdapter.java
@@ -38,7 +38,7 @@ public abstract class BaseMultiItemQuickAdapter<T extends MultiItemEntity, K ext
     protected int getDefItemViewType(int position) {
         T item = mData.get(position);
         if (item != null) {
-            return ((MultiItemEntity) item).getItemType();
+            return item.getItemType();
         }
         return DEFAULT_VIEW_TYPE;
     }

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -65,7 +65,7 @@ import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends RecyclerView.Adapter<K> {
+public abstract class BaseQuickAdapter<T, K extends BaseViewHolder<T>> extends RecyclerView.Adapter<K> {
 
     //load more
     private boolean mNextLoadEnable = false;
@@ -969,6 +969,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
 
     /**
      * override this method if you want to override click event logic
+     *
      * @param v
      * @param position
      */
@@ -978,6 +979,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
 
     /**
      * override this method if you want to override longClick event logic
+     *
      * @param v
      * @param position
      * @return
@@ -1567,12 +1569,14 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     }
 
     /**
-     * Implement this method and use the helper to adapt the view to the given item.
+     * Override this method and use the helper to adapt the view to the given item.
      *
      * @param helper A fully initialized helper.
      * @param item   The item that needs to be displayed.
      */
-    protected abstract void convert(K helper, T item);
+    protected void convert(K helper, T item) {
+        helper.onBind(item);
+    }
 
     /**
      * get the specific view by position,e.g. getViewByPosition(2, R.id.textView)

--- a/library/src/main/java/com/chad/library/adapter/base/BaseSectionQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseSectionQuickAdapter.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public abstract class BaseSectionQuickAdapter<T extends SectionEntity, K extends BaseViewHolder> extends BaseQuickAdapter<T, K> {
+public abstract class BaseSectionQuickAdapter<T extends SectionEntity, K extends BaseViewHolder<T>> extends BaseQuickAdapter<T, K> {
 
 
     protected int mSectionHeadResId;

--- a/library/src/main/java/com/chad/library/adapter/base/BaseViewHolder.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseViewHolder.java
@@ -46,7 +46,7 @@ import java.util.Set;
 /**
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
-public class BaseViewHolder extends RecyclerView.ViewHolder {
+public class BaseViewHolder<T> extends RecyclerView.ViewHolder {
 
     /**
      * Views indexed with their IDs
@@ -74,6 +74,7 @@ public class BaseViewHolder extends RecyclerView.ViewHolder {
      */
     Object associatedObject;
 
+    public T data;
 
     public BaseViewHolder(final View view) {
         super(view);
@@ -83,11 +84,14 @@ public class BaseViewHolder extends RecyclerView.ViewHolder {
         this.nestViews = new HashSet<>();
         convertView = view;
 
+    }
 
+    public void onBind(T data) {
+        this.data = data;
     }
 
     private int getClickPosition() {
-        if (getLayoutPosition()>=adapter.getHeaderLayoutCount()){
+        if (getLayoutPosition() >= adapter.getHeaderLayoutCount()) {
             return getLayoutPosition() - adapter.getHeaderLayoutCount();
         }
         return 0;


### PR DESCRIPTION
使用泛型解除viewholder与adapter耦合，把跟业务相关的逻辑放到viewholder.onbind里面。
修改抽象方法 convert 为BaseQuickAdapter里面的方法，并在调用viewholder的onBind方法。

主要修改BaseQuickAdapter，BaseViewHolder两个类，其余类修改主要是添加viewholder的泛型。详情请看MultipleItemQuickAdapter以及ImageTextHolder 的实现思路。

这样有两个好处：
第一：解耦viewholder，方便在其他adapter里面复用，减少冗余代码（最主要）。举个例子：如果adapterA与adapterB 有一个item 逻辑完全一致，以前代码需要些两遍。
第二：每个业务 adapter 可以少写一个convert 方法。